### PR TITLE
Update examples.md

### DIFF
--- a/docs/cli/graphql-transformer/examples.md
+++ b/docs/cli/graphql-transformer/examples.md
@@ -320,9 +320,9 @@ type Comment @model(subscriptions: null) {
 
 ```graphql
 type Subscription {
-  onCreateComment(commentTodoId: String): Comment @aws_subscribe(mutations: "createComment")
-  onUpdateComment(id: ID, commentTodoId: String): Comment @aws_subscribe(mutations: "updateComment")
-  onDeleteComment(id: ID, commentTodoId: String): Comment @aws_subscribe(mutations: "deleteComment")
+  onCreateComment(commentTodoId: String): Comment @aws_subscribe(mutations: ["createComment"])
+  onUpdateComment(id: ID, commentTodoId: String): Comment @aws_subscribe(mutations: ["updateComment"])
+  onDeleteComment(id: ID, commentTodoId: String): Comment @aws_subscribe(mutations: ["deleteComment"])
 }
 ```
 


### PR DESCRIPTION
Fixed "The mutations argument on the aws_subscribe directive has an invalid value"

_Issue #, if available:_

_Description of changes:_
The mutations argument should be lists, but it is string in the final example in the [document](https://docs.amplify.aws/cli/graphql-transformer/examples#filter-subscriptions-by-model-fields-andor-relations). After `amplify push`, it will return the error "The mutations argument on the aws_subscribe directive has an invalid value". So I guess, this code just missed the square brackets, and I added them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
